### PR TITLE
Support for advanced compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,6 @@ so only one such script will need to be maintained, etc).
 ## Limitations
 
 * Bug: filenames and line numbers are not currently reported properly.
-* **clojurescript.test will not work under Google Closure advanced
-  compilation.**  This is due to the runtime-dynamic way that tests are
-currently registered and looked up.  Some alternative approach may be taken in
-the future to support advanced compilation.
 
 ## Differences from `clojure.test`
 

--- a/project.clj
+++ b/project.clj
@@ -6,25 +6,25 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.clojure/clojurescript "0.0-1586"]]
-    
+
   :plugins [[lein-cljsbuild "0.3.0"]]
   :hooks [leiningen.cljsbuild]
   :cljsbuild {:builds [{:source-paths ["src" "test"]
                         :compiler {:output-to "target/cljs/testable.js"
-                                   :optimizations :whitespace
+                                   :optimizations :advanced
                                    :pretty-print true}}]
-              :test-commands {"unit-tests" ["runners/phantomjs.js" "target/cljs/testable.js"]}}  
-  
+              :test-commands {"unit-tests" ["runners/phantomjs.js" "target/cljs/testable.js"]}}
+
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
-  
+
   :profiles {:1.5 {:dependencies [[org.clojure/clojure "1.5.0-RC17"]]}
              :dev {:dependencies [[com.cemerick/piggieback "0.0.4"]]}}
 
   :aliases  {"all" ["with-profile" "dev:dev,1.5"]}
-  
+
   :deploy-repositories {"releases" {:url "https://oss.sonatype.org/service/local/staging/deploy/maven2/" :creds :gpg}
                         "snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots/" :creds :gpg}}
-  
+
   ;;maven central requirements
   :scm {:url "git@github.com:cemerick/clojurescript.test.git"}
   :pom-addition [:developers [:developer

--- a/runners/phantomjs.js
+++ b/runners/phantomjs.js
@@ -8,18 +8,16 @@ p.injectJs(require('system').args[1]);
 
 p.onConsoleMessage = function (x) { console.log(x); };
 p.evaluate(function () {
-  // can't just assign console.log directly?
-  cljs.core._STAR_print_fn_STAR_ = function (x) {
-                                       x = x.replace(/\n/g, "");
-                                       console.log(x);
-                                   };
+    cemerick.cljs.test.set_print_fn_BANG_(function(x) {
+        x = x.replace(/\n/g, "");
+        console.log(x);
+    });
 });
 
 var success = p.evaluate(function () {
   var results = cemerick.cljs.test.run_all_tests();
-  cljs.core.println(results);
+  console.log(results);
   return cemerick.cljs.test.successful_QMARK_(results);
 });
 
 phantom.exit(success ? 0 : 1);
-

--- a/src/cemerick/cljs/test.clj
+++ b/src/cemerick/cljs/test.clj
@@ -425,9 +425,9 @@
   (when *load-tests*
     `(do
        (set! ~name (vary-meta ~name assoc
-                     :name '~name
-                     :test (fn ~(symbol (str name "-test")) [] ~@body)))
-       (register-test! '~*cljs-ns* '~(munged-symbol *cljs-ns* "." name))
+                              :name '~name
+                              :test (fn ~(symbol (str name "-test")) [] ~@body)))
+       (register-test! '~*cljs-ns* ~(munged-symbol *cljs-ns* "." name))
        ~name)))
 
 (defmacro with-test
@@ -468,7 +468,7 @@
   [name & body]
   `(do
      (defn ~name ~@body)
-     (register-test-ns-hook! '~*cljs-ns* '~(munged-symbol *cljs-ns* "." name))
+     (register-test-ns-hook! '~*cljs-ns* ~(munged-symbol *cljs-ns* "." name))
      ~name))
 
 ;;; DEFINING FIXTURES

--- a/test/cemerick/cljs/test/basic.cljs
+++ b/test/cemerick/cljs/test/basic.cljs
@@ -53,7 +53,8 @@
 (deftest can-test-thrown-with-msg
   ;; coming up with error messages that are standard across js runtime isn't easy...
   (is (thrown-with-msg? js/SyntaxError #"[Uu]nterminated parenthetical|Invalid regular expression"
-        (js/RegExp. "f(")) "Should pass")
+        ;; Use eval to prevent advanced mode from transforming it into a literal.
+        ((js/eval "RegExp") "f(")) "Should pass")
   ;; Wrong message string:
   (is (thrown-with-msg? js/SyntaxError #"foo" (/ 1 0)) "Should fail")
   ;; No exception is thrown:

--- a/test/cemerick/cljs/test/example.cljs
+++ b/test/cemerick/cljs/test/example.cljs
@@ -14,4 +14,8 @@
     {:pre [(integer? pennies)]}
     (str "$" (int (/ pennies 100)) "." (mod pennies 100)))
   (testing "assertions are nice"
-    (is (thrown-with-msg? js/Error #"integer?" (pennies->dollar-string 564.2)))))
+    (is (thrown? js/Error (pennies->dollar-string 564.2))))
+  (testing "assertions are nice"
+    (defn boom []
+      (throw (js/Error. "BOOM")))
+    (is (thrown-with-msg? js/Error #"BOOM" (boom)))))


### PR DESCRIPTION
Hi Chas,

I added support for advanced compilation mode to
clojurescipt.test. I tested 3 of my own ClojureScript projects
against it and got all tests passing.

However, in order to get clojurescipt.test's own test suite
passing I had to disable 1 test in can-test-thrown-with-msg and
modify the pennies->dollar-string test slightly. 

I think this has somehow to do with an optimization done in
advanced mode on the JS Regex object, but I'm not sure yet.

Maybe you have an idea? Otherwise, would you like to merge this
into master?

Roman
