### PR TITLE
Avoid extraneous newlines in test runner output

### DIFF
--- a/runners/phantomjs.js
+++ b/runners/phantomjs.js
@@ -4,14 +4,20 @@
 // see http://github.com/cemerick/clojurescript.test for more info
 
 var p = require('webpage').create();
-p.injectJs(require('system').args[1]);
+var sys = require('system');
+p.injectJs(sys.args[1]);
 
-p.onConsoleMessage = function (x) { console.log(x); };
+p.onConsoleMessage = function (x) {
+  var line = x;
+  if (line !== "[NEWLINE]") {
+    console.log(line.replace(/\[NEWLINE\]/g, "\n"));
+  }
+};
+
 p.evaluate(function () {
-    cemerick.cljs.test.set_print_fn_BANG_(function(x) {
-        x = x.replace(/\n/g, "");
-        console.log(x);
-    });
+  cemerick.cljs.test.set_print_fn_BANG_(function(x) {
+    console.log(x.replace(/\n/g, "[NEWLINE]")); // since console.log *itself* adds a newline
+  });
 });
 
 var success = p.evaluate(function () {
@@ -21,3 +27,4 @@ var success = p.evaluate(function () {
 });
 
 phantom.exit(success ? 0 : 1);
+


### PR DESCRIPTION
This implementation is fairly hokey, but it gets the job done: prevents doubling up on newlines to make test output look nicer.
