### PR TITLE
Make sure logged objects are converted to string

### DIFF
--- a/resources/cemerick/cljs/test/runner.js
+++ b/resources/cemerick/cljs/test/runner.js
@@ -13,7 +13,7 @@ for (var i = 1; i < sys.args.length; i++) {
 }
 
 p.onConsoleMessage = function (x) {
-  var line = x;
+  var line = x.toString();
   if (line !== "[NEWLINE]") {
     console.log(line.replace(/\[NEWLINE\]/g, "\n"));
   }


### PR DESCRIPTION
Currently non string logged from tests won't be printed to the console output. Forcing the conversion to string allows to see some output.

Fixes #29.
