### PR TITLE
Partial solution to testing async apps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/clojurescript "0.0-1934"]]
+                 [org.clojure/clojurescript "0.0-1934"]
+                 [org.clojure/core.async "0.1.256.0-1bf8cf-alpha"]]
 
   :plugins [[lein-cljsbuild "1.0.0-alpha1"]]
 


### PR DESCRIPTION
Don't merge - opening this to get thoughts and feedback.

This patch allows tests to return a channel. core.async is used all the
way up the stack so that tests can wait on run-all-tests like:

```
(go
  (<! (run-all-tests))
  (prn "hooray we're done with all the tests!))
```

Two major outstanding problems:

1) because bindings aren't conveyed to go blocks, reporting
   functions (ie, assertions) inside go blocks aren't included in the
   final report

2) calls to (.log js/console) inside tests seem to be swallowed. I
   suspect his is also due to losing bindings inside go blocks.

This is sort of backwards compatible - the documentation never really
does anything with the result of run-all-tests so returning a channel
doesn't seem like serious breakage.
