### PR TITLE
Add note about requiring 'cemerick.cljs.test'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Here's a simple ClojureScript namespace that uses clojurescript.test:
     (is (thrown-with-msg? js/Error #"integer?" (pennies->dollar-string 564.2)))))
 ```
 
+**Note**: each namespace in your project must `(:require
+cemerick.cljs.test)` even if you only use macros. Otherwise, the ClojureScript
+compilation process won't include clojurescript.test in its output, resulting
+in an error similar to "`ReferenceError: Can't find variable: cemerick`".
+
 You can load this into a ClojureScript REPL, and run its tests using familiar functions:
 
 ```clojure


### PR DESCRIPTION
When I tried to setup simplest test I got `ReferenceError: Can't find variable: cemerick` and figured out I need to require `cemerick.cljs.test` at least in one of my files so it will be included by compiler to final js file. I think it should be mentioned in README. 
