### PR TITLE
Add rhino support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ jdk:
   - openjdk7
   - oraclejdk7
   - openjdk6
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq rhino

--- a/README.md
+++ b/README.md
@@ -178,11 +178,13 @@ arbitrary JavaScript expressions (useful for e.g. configuring runtime test
 properties...see the subsection below on using this capability, especially in
 conjunction with advanced compilation).
 
-To run your tests with node.js instead of `phantomjs`, just change the
+
+##### Node.js
+To run your tests with [node.js](http://nodejs.org/) instead of phantomjs, just change the
 executable name and the `:runner` keyword in your `:test-commands` vectors like so:
 
 ```
-:test-commands {"unit-tests" ["node" :node-runner 
+:test-commands {"unit-tests" ["node" :node-runner
                               ; extra code/files here...
                              ]}
 ```
@@ -190,13 +192,22 @@ executable name and the `:runner` keyword in your `:test-commands` vectors like 
 **Note that you must compile your ClojureScript code with
 `:optimizations :advanced` to run it on node.js.**
 
+##### Rhino
+To run your tests with [rhino](https://developer.mozilla.org/en/docs/Rhino), change the executable name and the `:runner` keyword in your `:test-commands` vectors like so:
+```
+:test-commands {"unit-tests" ["rhino" "-opt" "-1" :rhino-runner
+                              ; extra code/files here...
+                             ]}
+```
+Note that rhino doesn't support any HTML or DOM related functions and objects so it can be used mainly for business-only logic or you have to mock all DOM functions by yourself.
+
 clojurescript.test bundles test runner scripts for various environments
-(currently, phantomjs and node.js).  As long as you add clojurescript.test to
+(currently, phantomjs, node.js and rhino).  As long as you add clojurescript.test to
 your `project.clj` as a `:plugin`, then it will replace any occurrences of
-`:runner` and `:node-runner` in your `:test-commands` vectors with the path to
+`:runner`, `:node-runner` and `:rhino-runner` in your `:test-commands` vectors with the path to
 the corresponding test runner script.
 
-**Wanted: runners for other JavaScript environments, e.g. Rhino, XUL, the
+**Wanted: runners for other JavaScript environments, e.g. XUL, the
 headed browsers of all sorts, etc**
 
 All test runner scripts load the output of the ClojureScript compilation, run
@@ -285,7 +296,7 @@ your cljsc/lein-cljsbuild configuration.
 ## Need Help?
 
 Send a message to the [ClojureScript](http://groups.google.com/group/clojurescript)
-mailing list, or ping `cemerick` on freenode irc or 
+mailing list, or ping `cemerick` on freenode irc or
 [twitter](http://twitter.com/cemerick) if you have questions
 or would like to contribute patches.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.cemerick/clojurescript.test "0.2.2"
+(defproject com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"
   :description "Port of clojure.test targeting ClojureScript."
   :url "http://github.com/cemerick/clojurescript.test"
   :license {:name "Eclipse Public License"
@@ -21,7 +21,8 @@
                         :compiler {:output-to "target/cljs/advanced.js"
                                    :optimizations :advanced
                                    :pretty-print true}}]
-              :test-commands {"phantom-whitespace" ["phantomjs" :runner
+              :test-commands {; PhantomJS tests
+                              "phantom-whitespace" ["phantomjs" :runner
                                                     "window.literal_js_was_evaluated=true"
                                                     "target/cljs/whitespace.js"
                                                     "test/cemerick/cljs/test/extra_test_command_file.js"]
@@ -33,10 +34,28 @@
                                                   "window.literal_js_was_evaluated=true"
                                                   "target/cljs/advanced.js"
                                                   "test/cemerick/cljs/test/extra_test_command_file.js"]
+
+                              ; Node.js tests
                               "node" ["node" :node-runner
                                       "this.literal_js_was_evaluated=true"
                                       "target/cljs/advanced.js"
-                                      "test/cemerick/cljs/test/extra_test_command_file.js"]}}
+                                      "test/cemerick/cljs/test/extra_test_command_file.js"]
+
+                              ; Rhino tests
+                              "rhino-whitespace" ["rhino" "-opt" "-1" :rhino-runner
+                                                  "this.literal_js_was_evaluated=true"
+                                                  "target/cljs/whitespace.js"
+                                                  "test/cemerick/cljs/test/extra_test_command_file.js"]
+                              "rhino-simple" ["rhino" "-opt" "-1" :rhino-runner
+                                                  "this.literal_js_was_evaluated=true"
+                                                  "target/cljs/simple.js"
+                                                  "test/cemerick/cljs/test/extra_test_command_file.js"]
+                              "rhino-advanced" ["rhino" "-opt" "-1" :rhino-runner
+                                                  "this.literal_js_was_evaluated=true"
+                                                  "target/cljs/advanced.js"
+                                                  "test/cemerick/cljs/test/extra_test_command_file.js"]
+
+}}
 
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 
@@ -45,7 +64,7 @@
                       :plugins [[com.cemerick/austin "0.1.3"]]}
              ; self-reference and chained `lein install; lein test` invocation
              ; needed to use the project as its own plugin. Leiningen :-(
-             :self-plugin [:default {:plugins [[com.cemerick/clojurescript.test "0.2.2-SNAPSHOT"]]}]}
+             :self-plugin [:default {:plugins [[com.cemerick/clojurescript.test "0.2.3-SNAPSHOT"]]}]}
 
   :aliases  {"cleantest" ["with-profile" "self-plugin:self-plugin,latest"
                           "do" "clean," "test," "cljsbuild" "test"]

--- a/resources/cemerick/cljs/test/rhino_runner.js
+++ b/resources/cemerick/cljs/test/rhino_runner.js
@@ -1,0 +1,29 @@
+arguments.forEach(function (arg) {
+    print(arg)
+    if (new java.io.File(arg).exists()) {
+      try {
+        load(arg);
+      } catch (e) {
+        print("Error in file: \"" + arg + "\"");
+        print(e);
+      }
+    } else {
+      try {
+        eval("(function () {" + arg + "})()");
+      } catch (e) {
+        print("Could not evaluate expression: \"" + arg + "\"");
+        print(e);
+      }
+    }
+});
+
+cemerick.cljs.test.set_print_fn_BANG_(function(x) {
+    // since console.log *itself* adds a newline
+    var x = x.replace(/\n$/, "");
+    if (x.length > 0) print(x);
+});
+
+var results = cemerick.cljs.test.run_all_tests();
+var success = cemerick.cljs.test.successful_QMARK_(results);
+
+java.lang.System.exit(success ? 0 : 1);

--- a/src/clojurescript/test/plugin.clj
+++ b/src/clojurescript/test/plugin.clj
@@ -18,12 +18,13 @@
                  version))
     version))
 
-(defn runner-path! [[runner resource-file]]
+(defn runner-path! [[runner filename]]
   "Creates a temp file for the given runner resource file"
-  (let [runner-path (.getAbsolutePath
+  (let [full-path (str "cemerick/cljs/test/" filename)
+        runner-path (.getAbsolutePath
                      (doto (File/createTempFile (name runner) ".js")
                        (.deleteOnExit)
-                       (#(copy (slurp (resource resource-file)) %))))]
+                       (#(copy (slurp (resource full-path)) %))))]
 
     [runner runner-path]))
 
@@ -36,14 +37,15 @@ associating the runner keyword with the corresponding temp file"
   "Does two things:
 
 1. Modify all :cljsbuild :test-command vectors, swapping :runner, :node-runner,
-  and :nodejs-runner keywords for the string path to the corresponding packaged
-  script.
+  :nodejs-runner and :rhino-runner keywords for the string path to the
+  corresponding packaged script.
 2. Add [com.cemerick/clojurescript-test \"CURRENT_VERSION\"] as a project
   dependency."
   [project]
-  (let [runners [[:runner "cemerick/cljs/test/runner.js"]
-                 [:node-runner "cemerick/cljs/test/node_runner.js"]
-                 [:nodejs-runner "cemerick/cljs/test/node_runner.js"]]
+  (let [runners [[:runner "runner.js"]
+                 [:node-runner "node_runner.js"]
+                 [:nodejs-runner "node_runner.js"]
+                 [:rhino-runner "rhino_runner.js"]]
         runner-paths (runner-paths! runners)]
     (-> project
         (update-in [:dependencies]


### PR DESCRIPTION
Added runner script for rhino. Also added functionality to use rhino out of box without need of manual downloading rhino. Rhino is available in maven so I added dependency to it in `project.clj`. In middleware we can get full path to rhino jar using java class methods. Unfortunately it leads to additional complexity inside middleware as now we need replace `:rhino` with several strings: `["java" "-jar" "path/to/rhino.jar" "-opt" "-1"]` but I think it worth it. 

Feel free to leave comments, happy to fix them before merge.

Nikita 
