### PR TITLE
Display helpful error message when cemerick.cljs.test is not required

### DIFF
--- a/resources/cemerick/cljs/test/node_runner.js
+++ b/resources/cemerick/cljs/test/node_runner.js
@@ -1,32 +1,52 @@
-var path = require("path"),
-  fs = require("fs"),
-  args = process.argv.slice(2);
+var path = require("path");
+var fs = require("fs");
+var args = process.argv.slice(2);
+
+var haveCljsTest = function () {
+  return (typeof cemerick !== "undefined" &&
+	  typeof cemerick.cljs !== "undefined" &&
+	  typeof cemerick.cljs.test !== "undefined" &&
+	  typeof cemerick.cljs.test.run_all_tests === "function");
+};
 
 args.forEach(function (arg) {
     var file = path.join(process.cwd(), arg);
     if (fs.existsSync(file)) {
       try {
-        // using eval instead of require here so that `this` is the "real"
-        // top-level scope, not the module
+        // Using eval instead of require here so that `this` is the "real"
+        // top-level scope, not the module.
         eval("(function () {" + fs.readFileSync(file, {encoding: "UTF-8"}) + "})()");
       } catch (e) {
-        console.log("Error in file: \"" + file + "\"");
-        console.log(e);
+	if (haveCljsTest()) {
+          console.error("Error in file: \"" + file + "\"");
+          console.error(e);
+	} else {
+	  var messageLines = [
+	    "",
+	    "ERROR: cemerick.cljs.test was not required.",
+	    "",
+	    "You can resolve this issue by ensuring [cemerick.cljs.test] appears",
+	    "in the :require clause of your test suite namespaces.",
+	    ""
+	  ];
+	  console.log(messageLines.join("\n"));
+	  process.exit(1);
+	}
       }
     } else {
       try {
         eval("(function () {" + arg + "})()");
       } catch (e) {
-        console.log("Could not evaluate expression: \"" + arg + "\"");
-        console.log(e);
+        console.error("Could not evaluate expression: \"" + arg + "\"");
+        console.error(e);
       }
     }
 });
 
 cemerick.cljs.test.set_print_fn_BANG_(function(x) {
-    // since console.log *itself* adds a newline 
-    var x = x.replace(/\n$/, "");
-    if (x.length > 0) console.log(x);
+  // since console.log *itself* adds a newline
+  var x = x.replace(/\n$/, "");
+  if (x.length > 0) console.log(x);
 });
 
 var success = (function() {

--- a/resources/cemerick/cljs/test/rhino_runner.js
+++ b/resources/cemerick/cljs/test/rhino_runner.js
@@ -1,11 +1,31 @@
+var haveCljsTest = function () {
+  return (typeof cemerick !== "undefined" &&
+	  typeof cemerick.cljs !== "undefined" &&
+	  typeof cemerick.cljs.test !== "undefined" &&
+	  typeof cemerick.cljs.test.run_all_tests === "function");
+};
+
 arguments.forEach(function (arg) {
-    print(arg)
+    print(arg);
     if (new java.io.File(arg).exists()) {
       try {
         load(arg);
       } catch (e) {
-        print("Error in file: \"" + arg + "\"");
-        print(e);
+	if (haveCljsTest()) {
+	  print("Error in file: \"" + arg + "\"");
+	  print(e);
+	} else {
+	  var messageLines = [
+	    "",
+	    "ERROR: cemerick.cljs.test was not required.",
+	    "",
+	    "You can resolve this issue by ensuring [cemerick.cljs.test] appears",
+	    "in the :require clause of your test suite namespaces.",
+	    ""
+	  ];
+	  print(messageLines.join("\n"));
+	  java.lang.System.exit(1);
+	}
       }
     } else {
       try {


### PR DESCRIPTION
This should solve #47. I'm a little new to scripting phantom and rhino but this seems to work well. My guess is you'll have feedback either way.
