### PR TITLE
Helpful error when missing cemerick.cljs.test

### DIFF
--- a/resources/cemerick/cljs/test/rhino_runner.js
+++ b/resources/cemerick/cljs/test/rhino_runner.js
@@ -29,11 +29,35 @@ var setTimeout, clearTimeout, setInterval, clearInterval;
 
 })()
 
+var haveCljsTest = function () {
+    return (typeof cemerick !== "undefined" &&
+        typeof cemerick.cljs !== "undefined" &&
+        typeof cemerick.cljs.test !== "undefined" &&
+        typeof cemerick.cljs.test.run_all_tests === "function");
+};
+
+var failIfCljsTestUndefined = function () {
+    if (!haveCljsTest()) {
+        var messageLines = [
+            "",
+            "ERROR: cemerick.cljs.test was not required.",
+            "",
+            "You can resolve this issue by ensuring [cemerick.cljs.test] appears",
+            "in the :require clause of your test suite namespaces.",
+            "Also make sure that your build has actually included any test files.",
+            ""
+        ];
+        print(messageLines.join("\n"));
+        java.lang.System.exit(1);
+    }
+}
+
 arguments.forEach(function (arg) {
     if (new java.io.File(arg).exists()) {
         try {
             load(arg);
         } catch (e) {
+            failIfCljsTestUndefined();
             print("Error in file: \"" + arg + "\"");
             print(e);
         }
@@ -46,6 +70,8 @@ arguments.forEach(function (arg) {
         }
     }
 });
+
+failIfCljsTestUndefined(); // check this before trying to call set_print_fn_BANG_
 
 cemerick.cljs.test.set_print_fn_BANG_(function(x) {
     // since console.log *itself* adds a newline


### PR DESCRIPTION
Display a helpful error message instead of
"ReferenceError: Can't find variable: cemerick"
when either there were no test files included in
the build or when they did not require
cemerick.cljs.test.

Based on #51 and the latest code, improved to also kick in if there is no test file and to warn that
Node does not work with none/whitespace optimizations.
