### PR TITLE
Fix printing of async test summary.

### DIFF
--- a/src/cemerick/cljs/test.cljs
+++ b/src/cemerick/cljs/test.cljs
@@ -438,7 +438,7 @@ argument immediately, and no watcher will be registered."
   (let [async-test-env (-> test-env :async maybe-deref)
         tests (-> async-test-env :test)]
     (when (pos? tests)
-      (print-summary async-test-env))))
+      (print-summary (merge-with + test-env async-test-env)))))
 
 (defn- test-summary
   [test-env]


### PR DESCRIPTION
Fixes #61.
- The results from async tests are now only printed if any were actually run. 
- Additionally, the printed summary for the async test results will now only include statistics for the async tests themselves - previously, the sync and async tests were added together.

Example output without async tests:

```
Testing core-async-tutorial.core-test 

FAIL in (core-async-tutorial.core-test/fail-test) (:)
expected: false
  actual: false

Ran 3 tests containing 3 assertions.
Testing complete: 1 failures, 0 errors.
```

Example output with async tests:

```
Testing core-async-tutorial.core-test 

FAIL in (core-async-tutorial.core-test/fail-test) (:)
expected: false
  actual: false

Testing core-async-tutorial.async-test 

Ran 3 tests containing 3 assertions.
Testing complete: 1 failures, 0 errors.
Waiting on 2 asynchronous tests to complete.

Testing core-async-tutorial.async-test (async)

FAIL in (core-async-tutorial.async-test/async-fail-test) (:)
expected: false
  actual: false

Ran 2 tests containing 2 assertions.
Testing complete: 1 failures, 0 errors.
```
