### PR TITLE
Log errors in test files

### DIFF
--- a/resources/cemerick/cljs/test/node_runner.js
+++ b/resources/cemerick/cljs/test/node_runner.js
@@ -34,9 +34,9 @@ args.forEach(function (arg) {
       try {
         // using eval instead of require here so that `this` is the "real"
         // top-level scope, not the module
-        eval("(function () {" + fs.readFileSync(file, {encoding: "UTF-8"}) + "})()");
+        var content = fs.readFileSync(file, {encoding: "UTF-8"});
+        eval("(function () {" + content + "})()");
       } catch (e) {
-        failIfCljsTestUndefined();
         console.log("Error in file: \"" + file + "\"");
         console.log(e);
       }


### PR DESCRIPTION
Errors were getting swallowed due to an extra `failIfCljsTestUndefined()` call.  

Helpful for tracking down [Issue 68](https://github.com/cemerick/clojurescript.test/issues/68)
