### PR TITLE
Improve error when runner passed missing file path

### DIFF
--- a/resources/cemerick/cljs/test/runner.js
+++ b/resources/cemerick/cljs/test/runner.js
@@ -5,11 +5,19 @@ var p = require('webpage').create();
 var fs = require('fs');
 var sys = require('system');
 
+var f1 = "(function () { "
+    + "try { ";
+var f2 = "; } catch (err) { e = new Error('";
+var f3 = "' + "
+    + "' is not a file, and evaluating as an expression threw: \"' + "
+    + "err.message + '\"'); throw e; }"
+    + " })";
+
 for (var i = 1; i < sys.args.length; i++) {
     if (fs.exists(sys.args[i])) {
         if (!p.injectJs(sys.args[i])) throw new Error("Failed to inject " + sys.args[i]);
     } else {
-        p.evaluateJavaScript("(function () { " + sys.args[i] + ";" + " })");
+        p.evaluateJavaScript(f1 + sys.args[i] + f2 + sys.args[i] + f3);
     }
 }
 


### PR DESCRIPTION
When the runner is passed a non existing file, the runner attempts to evaluate
the path as a javascript expression, which can lead to a non obvious error
message.

Explicitly add that an expression was not found as a file to the error message
thrown when an expression passed to the runner is evaluated.

Note: maybe not the nicest implementation - I don't get to write much
javascript.